### PR TITLE
Added/fixed paste field params support

### DIFF
--- a/scripts/CFGRescale.py
+++ b/scripts/CFGRescale.py
@@ -227,6 +227,15 @@ class Script(scripts.Script):
 def on_infotext_pasted(infotext, params):
     if "CFG Rescale" not in params:
         params["CFG Rescale"] = 0
+
+        if "CFG Rescale φ" in params:
+            params["CFG Rescale"] = params["CFG Rescale φ"]
+            del params["CFG Rescale φ"]
+
+        if "CFG Rescale phi" in params and scripts.scripts_txt2img.script("Neutral Prompt") is None:
+            params["CFG Rescale"] = params["CFG Rescale phi"]
+            del params["CFG Rescale phi"]
+
     if "DDIM Trailing" not in params:
         params["DDIM Trailing"] = False
 


### PR DESCRIPTION
This resolves https://github.com/Seshelle/CFG_Rescale_webui/issues/1

There is a caveat though, anybody that has previously used the extention will still have paste of CFG Rescale non-functional due to https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12768. The TL;DR is that the current version of the ext used ints for the slider values which are stored in `ui-config.json`, this breaks paste under this exact condition.

Possible workaround is to do any one of these:
- Reset `ui-config.json`
- Delete all entries in `ui-config.json` for `customscript/CFGRescale.py/*`
- Edit all `customscript/CFGRescale.py/*/CFG Rescale/*` values to float in `ui-config.json`

If https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12768 is not to be fixed, then the perment workaround that would not require user intervention would be to change the label on the "CFG Rescale" slider to anything else. I would have already done this, but I want to see if https://github.com/AUTOMATIC1111/stable-diffusion-webui/issues/12768 gets a response first.