### PR TITLE
Added support for `<cfg_rescale:[number]>` override in prompts

### DIFF
--- a/scripts/CFGRescale.py
+++ b/scripts/CFGRescale.py
@@ -108,7 +108,11 @@ class Script(scripts.Script):
                 rescale = rescale_override
             
             globals()['cfg_rescale_fi'] = rescale
+        else:
+            # rescale value is being set from xyz_grid
+            rescale = globals()['cfg_rescale_fi']
         globals()['enable_furry_cocks'] = True
+
         sd_samplers_kdiffusion.CFGDenoiser.combine_denoised = self.cfg_replace
 
         if rescale > 0:


### PR DESCRIPTION
A number of extensions and things that use the API don't support setting random params for other extensions. Contributing support for it upstream to those other projects is slow and not a guaranty they will merge the PR.

My workaround is to just add support for an override param in the prompt itself. The upside is that this also adds support for having a different cfg rescale for highresfix, which is really needed is using a different model for HRF. The prompt prama is removed from the prompt before extra_networks parses the prompt, so it shouldn't have any weird side-effects there if any of that changes in the future.

I did not clamp the value since xyz grid doesn't either, which makes this another method to try stupid values for shits and giggles.

This PR also include a quick fix to image metadata from xyz grid showing the incorrect cfg rescale value. Currently it will always embed the slider value instead.